### PR TITLE
Misc fixes for Python 3

### DIFF
--- a/authy/__init__.py
+++ b/authy/__init__.py
@@ -6,7 +6,7 @@ class AuthyException(Exception):
     pass
 
 class AuthyFormatException(AuthyException):
-	pass
+    pass
 
 class AuthyApiException(AuthyException):
 

--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -19,22 +19,30 @@ class Resource(object):
         self.api_key = api_key
         self.def_headers = self.__default_headers()
 
-    def post(self, path, data={}):
+    def post(self, path, data=None):
         return self.request("POST", path, data, {'Content-Type': 'application/json'})
 
-    def get(self, path, data = {}):
+    def get(self, path, data=None):
         return self.request("GET", path, data)
 
-    def put(self, path, data = {}):
+    def put(self, path, data=None):
         return self.request("PUT", path, data, {'Content-Type': 'application/json'})
 
-    def delete(self, path, data={}):
+    def delete(self, path, data=None):
         return self.request("DELETE", path, data)
 
-    def request(self, method, path, data={}, headers={}):
+    def request(self, method, path, data=None, req_headers=None):
+        if data is None:
+            data = {}
+
+        if req_headers is None:
+            req_headers = {}
+
         url = self.api_uri + path
         params = {"api_key": self.api_key}
-        headers = self.def_headers.update(headers)
+
+        headers = self.def_headers
+        headers.update(req_headers)
 
         if method == "GET":
             params.update(data)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -22,27 +22,27 @@ class TokensTest(unittest.TestCase):
         try:
             token = self.resource.verify(user.id, 'token')
             self.fail()
-        except Exception, e:
+        except Exception as e:
             self.assertIsInstance(e, AuthyFormatException)
-            self.assertEqual(e.message, 'Invalid Token. Only digits accepted.')
+            self.assertEqual(str(e), 'Invalid Token. Only digits accepted.')
 
     def test_verify_digits_authy_id(self):
         user = self.users.create('test@example.com', '310-781-0860', 1)
         try:
             token = self.resource.verify('user.id', '0000000')
             self.fail()
-        except Exception, e:
+        except Exception as e:
             self.assertIsInstance(e, AuthyFormatException)
-            self.assertEqual(e.message, 'Invalid Authy id. Only digits accepted.')
+            self.assertEqual(str(e), 'Invalid Authy id. Only digits accepted.')
 
     def test_verify_longer_token(self):
         user = self.users.create('test@example.com', '310-781-0860', 1)
         try:
             token = self.resource.verify(user.id, '00000001111')
             self.fail()
-        except Exception, e:
+        except Exception as e:
             self.assertIsInstance(e, AuthyFormatException)
-            self.assertEqual(e.message, 'Invalid Token. Unexpected length.')
+            self.assertEqual(str(e), 'Invalid Token. Unexpected length.')
 
     def test_verify_invalid_token(self):
         user = self.users.create('test@example.com', '310-781-0860', 1)


### PR DESCRIPTION
- Fix the tests to run on Python 3 instead of failing with syntax errors.
- Fix a raw tab where a space should be (upstream error).
- Fix up resource.py to use dicts correctly.
